### PR TITLE
Add responsive navbar with active state highlighting

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,7 +3,7 @@ import { useContext, useState } from "react";
 import logo from "../assets/logo.jpeg";
 import Genres from "./Genres";
 import { Input } from "./ui/input";
-import { Link, useNavigate } from "react-router-dom";
+import { NavLink, useNavigate } from "react-router-dom";
 import { SearchResultContext } from "@/contex/searchResult.context";
 
 type NavbarProps = {
@@ -14,6 +14,7 @@ type NavbarProps = {
 const Navbar = ({ theme, toggleTheme }: NavbarProps) => {
   const navigate = useNavigate();
   const { searchText, setSearchText } = useContext(SearchResultContext);
+  const [open, setOpen] = useState(false);
 
   const handelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchText(e.target.value);
@@ -22,23 +23,25 @@ const Navbar = ({ theme, toggleTheme }: NavbarProps) => {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    navigate(`/search/${searchText}`);
-
-    if (e.target.value.length === 0) {
-      navigate(`/movies`);
+    if (!searchText.trim()) {
+      navigate("/movies");
+    } else {
+      navigate(`/search/${searchText}`);
     }
   };
 
-  // console.log(searchText)
+  const activeClass = ({ isActive }: { isActive: boolean }) =>
+    isActive ? "font-semibold underline" : "opacity-80 hover:opacity-100";
 
   return (
-    <div className="flex justify-between md:px-10 sm:px-5 px-5 items-center gap-3 text-xl my-3">
+    <div className="relative flex justify-between md:px-10 sm:px-5 px-5 items-center gap-3 text-xl my-3">
       <img
         src={logo}
         alt="logo"
         className="md:h-14 sm:h-9 h-9 hover:opacity-80 cursor-pointer"
         onClick={() => navigate("/")}
       />
+
       <div className="flex gap-3 items-center">
         <form onSubmit={handleSubmit}>
           <Input
@@ -48,6 +51,7 @@ const Navbar = ({ theme, toggleTheme }: NavbarProps) => {
             onChange={handelChange}
           />
         </form>
+
         <button
           onClick={toggleTheme}
           className="px-3 py-1 rounded-full border text-sm hover:opacity-80"
@@ -55,18 +59,35 @@ const Navbar = ({ theme, toggleTheme }: NavbarProps) => {
           {theme === "light" ? "🌙" : "☀"}
         </button>
 
-        <div className="md:block sm:hidden hidden">
-          <div className="flex gap-6 items-center">
-            <Genres />
-            <Link to={"/movies"}>
-              <div>Movies</div>
-            </Link>
-            <Link to={"/tvshows"}>
-              <div>Tv Shows</div>
-            </Link>
-          </div>
+        <button
+          className="md:hidden text-2xl"
+          onClick={() => setOpen(!open)}
+        >
+          ☰
+        </button>
+
+        <div className="md:flex hidden gap-6 items-center">
+          <Genres />
+          <NavLink to="/movies" className={activeClass}>
+            Movies
+          </NavLink>
+          <NavLink to="/tvshows" className={activeClass}>
+            Tv Shows
+          </NavLink>
         </div>
       </div>
+
+      {open && (
+        <div className="absolute top-16 right-5 flex flex-col gap-3 bg-background border p-4 rounded-xl md:hidden">
+          <Genres />
+          <NavLink to="/movies" className={activeClass} onClick={() => setOpen(false)}>
+            Movies
+          </NavLink>
+          <NavLink to="/tvshows" className={activeClass} onClick={() => setOpen(false)}>
+            Tv Shows
+          </NavLink>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This PR adds a responsive navigation bar to improve overall navigation and usability.

- Includes primary navigation links
- Highlights the active page for better clarity
- Works across desktop and mobile screen sizes
- Adds a mobile-friendly menu

Screenshots are included for reference.
<img width="918" height="723" alt="Screenshot 2026-02-02 220129" src="https://github.com/user-attachments/assets/469cee80-0128-4a1b-872b-57560a165fdd" />
<img width="922" height="725" alt="Screenshot 2026-02-02 220015" src="https://github.com/user-attachments/assets/5e808e17-b6d8-4ec5-abe4-81e8e6bdf0ee" />